### PR TITLE
red window border removal

### DIFF
--- a/themes/signed-dark-pro.color-theme.json
+++ b/themes/signed-dark-pro.color-theme.json
@@ -13,9 +13,6 @@
         "descriptionForeground": "#777777",
         "errorForeground": "#ec3a37f5",
         "icon.foreground": "#ffffff",
-        /* https://code.visualstudio.com/api/references/theme-color#window-border */
-        "window.activeBorder": "#ff0000",
-        "window.inactiveBorder": "#ff0000",
         /* https://code.visualstudio.com/api/references/theme-color#text-colors */
         "textBlockQuote.background": "#111111",
         "textBlockQuote.border": "#0040ff",


### PR DESCRIPTION
Here is the code I propose removing! It would remove the red border that shows up on Windows.
As is:
![image](https://user-images.githubusercontent.com/45426887/142901760-d803658f-097d-4f02-b227-f2573c90be43.png)

With my pull request, the result should look like this:
![image](https://user-images.githubusercontent.com/45426887/142901821-53868a61-c99a-4d39-88b8-58f1e4e3fc37.png)
