### PR TITLE
recolor basic checkboxes

### DIFF
--- a/themes/signed-dark-pro.color-theme.json
+++ b/themes/signed-dark-pro.color-theme.json
@@ -26,9 +26,9 @@
         "button.background": "#0040ff",
         "button.foreground": "#ffffff",
         "button.hoverBackground": "#0080ff",
-        "checkbox.background": "#ff0000",
-        "checkbox.foreground": "#ff0000",
-        "checkbox.border": "#ff0000",
+        "checkbox.background": "#080808",
+        "checkbox.foreground": "#ffffff",
+        "checkbox.border": "#333333",
         /* https://code.visualstudio.com/api/references/theme-color#dropdown-control */
         "dropdown.background": "#080808",
         "dropdown.listBackground": "#000000",


### PR DESCRIPTION
The current coloring makes basic checkboxes in VS Code an opaque red; it's impossible to see if they are checked or unchecked. It is easiest to see this on the welcome page (__Help > Get Started__):
![checkbox showing red on checked or unchecked](https://user-images.githubusercontent.com/45426887/155549067-9604198b-20de-47e6-a24b-78470ecb7930.gif)

This change matches the checkbox formatting in the VS Code settings menu so the selection status is actually visible.
![checkbox showing black, with a checkmark when checked](https://user-images.githubusercontent.com/45426887/155549537-55e81616-d398-4617-99ff-ee7a10bc1fc6.gif)

Let me know if there are any questions or issues!
