### PR TITLE
remove harsh red on centered background

### DIFF
--- a/themes/signed-dark-pro.color-theme.json
+++ b/themes/signed-dark-pro.color-theme.json
@@ -145,7 +145,6 @@
         "tab.inactiveModifiedBorder": "#ff0000",
         "tab.unfocusedActiveModifiedBorder": "#ff0000",
         "tab.unfocusedInactiveModifiedBorder": "#ff0000",
-        "editorPane.background": "#000000",
         /* https://code.visualstudio.com/api/references/theme-color#editor-colors */
         "editor.background": "#000000",
         "editor.foreground": "#FFFFFF",

--- a/themes/signed-dark-pro.color-theme.json
+++ b/themes/signed-dark-pro.color-theme.json
@@ -145,7 +145,7 @@
         "tab.inactiveModifiedBorder": "#ff0000",
         "tab.unfocusedActiveModifiedBorder": "#ff0000",
         "tab.unfocusedInactiveModifiedBorder": "#ff0000",
-        "editorPane.background": "#ff0000",
+        "editorPane.background": "#000000",
         /* https://code.visualstudio.com/api/references/theme-color#editor-colors */
         "editor.background": "#000000",
         "editor.foreground": "#FFFFFF",


### PR DESCRIPTION
When you enter either Centered or Zen mode, two large red bars show up on either side of the screen around the file you are working on. This is stark and bright, so I figured a switch to a regular black should work fine. I found the attribute set in the `color-theme.json` under `editorPane.background`.

Before fix:  
![image](https://user-images.githubusercontent.com/45426887/161763772-ea99f1c4-b80f-4249-837c-2e222611c35c.png)

After fix:  
![image](https://user-images.githubusercontent.com/45426887/161764277-c4f36eda-b0dd-47f9-bf15-2ddedb1bf4ee.png)
